### PR TITLE
bug: update json reader to use twisted events from json reader

### DIFF
--- a/push_processor/handler.py
+++ b/push_processor/handler.py
@@ -3,6 +3,7 @@ import json
 import os
 
 import redis
+from twisted.logger import eventsFromJSONLogFile
 
 from push_processor.aws_helpers import s3_open
 from push_processor.db import (
@@ -79,9 +80,6 @@ def process_heka_stream(redis_server, processor, stream):
 
 
 def process_json_stream(redis_server, processor, stream):
-    json_line = stream.readline()
-    while json_line:
-        msg = Message(json=json.loads(json_line))
-        processor.process_message(msg)
-        json_line = stream.readline()
+    for msg in eventsFromJSONLogFile(stream):
+        processor.process_message(Message(json=msg))
     dump_latest_messages_to_redis(redis_server, processor.latest_messages)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ boto3==1.2.6
 gzip_reader==0.1
 protobuf==2.6.1
 redis==2.10.5
+twisted==16.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ psutil==4.0.0
 mock==1.3.0
 nose==1.3.7
 coverage==4.0.3
+twisted==16.0.0


### PR DESCRIPTION
JSON spec indicates a record separator to avoid issues with valid
JSON payloads that can contain \n. Using the robust twisted json
event reader, JSON payloads are read from the stream.

Closes #3 

@jrconlin r?
