### PR TITLE
feat: read processor settings from root of s3 dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,17 @@ $(HERE)/lenv:
 	virtualenv lenv
 	$(HERE)/lenv/bin/pip install -r lambda-requirements.txt
 	echo "#" > lenv/lib/python2.7/site-packages/zope/__init__.py
-	echo "#" > lenv/lib/python2.7/site-packages/repoze/__init__.py
 	echo "#" > lenv/lib/python2.7/site-packages/google/__init__.py
 	$(HERE)/lenv/bin/python setup.py develop
 
 lambda-package: $(HERE)/lenv
 	pip install lambda-uploader
+	rm -rf lenv/lib/python2.7/site-packages/pip*
+	rm -rf lenv/lib/python2.7/site-packages/twisted/trial
+	rm -rf lenv/lib/python2.7/site-packages/twisted/web
+	rm -rf lenv/lib/python2.7/site-packages/twisted/words
+	rm -rf lenv/lib/python2.7/site-packages/twisted/conch
+	rm -rf lenv/lib/python2.7/site-packages/twisted/internet
+	rm -rf lenv/lib/python2.7/site-packages/twisted/mail
+	rm -rf lenv/lib/python2.7/site-packages/twisted/test
 	$(HERE)/ppenv/bin/lambda-uploader --virtualenv=lenv --no-upload

--- a/lambda-requirements.txt
+++ b/lambda-requirements.txt
@@ -1,5 +1,3 @@
-git+https://github.com/mozilla-services/push-messages.git@7cf9ea53141f124d8131d65ff7a1a7b32afef8e0#egg=push-messages
-boto3==1.2.6
 gzip_reader==0.1
 protobuf==2.6.1
 redis==2.10.5

--- a/lambda.json
+++ b/lambda.json
@@ -13,7 +13,10 @@
     "ppenv",
     "lenv",
     "/*.txt",
-    "/*.json"
+    "/*.json",
+    "Makefile",
+    "/setup.*",
+    "/*.md"
   ],
   "timeout": 30,
   "memory": 128

--- a/push_processor/db.py
+++ b/push_processor/db.py
@@ -1,10 +1,17 @@
 import json
-from push_messages.db import KeyResource
+
+import boto3
+from boto3.dynamodb.conditions import Key
 
 
 def get_all_keys(tablename):
     """Return all the public keys in the database"""
-    return [x["pubkey"] for x in KeyResource(tablename).all_keys()]
+    dynamodb = boto3.resource('dynamodb')
+    table = dynamodb.Table(tablename)
+    response = table.query(
+        KeyConditionExpression=Key('options').eq('public_keys')
+    )
+    return [x["pubkey"] for x in response['Items']]
 
 
 def dump_latest_messages_to_redis(redis_server, messages):

--- a/push_processor/processor/pubkey.py
+++ b/push_processor/processor/pubkey.py
@@ -4,11 +4,15 @@ from collections import defaultdict, deque
 class PubKeyProcessor(object):
     def __init__(self, pubkey_list):
         # Store public keys as hash for fast lookup
+        self.total = 0
+        self.flagged = 0
         self.pubkeys = {k: True for k in pubkey_list}
         self.latest_messages = defaultdict(lambda: deque(maxlen=100))
 
     def process_message(self, message):
         """Process a message and store metadata for top matches"""
+        self.total += 1
+
         # Need a message field and jwt
         if "message" not in message.fields or "jwt" not in message.fields:
             return
@@ -25,4 +29,5 @@ class PubKeyProcessor(object):
         if message_key not in self.pubkeys:
             return
 
+        self.flagged += 1
         self.latest_messages[message_key].append(message)

--- a/push_processor/tests/test_handler.py
+++ b/push_processor/tests/test_handler.py
@@ -5,11 +5,13 @@ import StringIO
 import unittest
 import uuid
 
+import push_messages.tests as pmtests
 import redis
 from mock import Mock, patch
-from nose.tools import eq_
+from nose.tools import eq_, raises
 
-import push_messages.tests as pmtests
+from push_processor.handler import ConfigException
+
 
 TEST_MESSAGE = """\
 {"EnvVersion": "2.0", "Severity": 5, "Timestamp": 1.457400685716216e+18, \
@@ -39,16 +41,133 @@ def tearDown():
     pmtests.tearDown()
 
 
+class Effect(object):
+    def __init__(self, responses):
+        self._index = 0
+        self._responses = responses
+
+    def __call__(self, *args, **kwargs):
+        i = self._index
+        self._index += 1
+        if callable(self._responses[i]):
+            return self._responses[i](*args, **kwargs)
+        else:
+            return self._responses[i]
+
+
 class TestHandler(unittest.TestCase):
-    def test_lambda(self):
+    def setUp(self):
         import push_processor.handler as handler
+        self._orig_s3_open = handler.aws_helpers.s3_open
+        handler.Lambda._reset()
+
+    def tearDown(self):
+        import push_processor.handler as handler
+        handler.Lambda.s3_open = staticmethod(handler.aws_helpers.s3_open)
+
+    @raises(ConfigException)
+    def test_lamda_no_settings(self):
+        import push_processor.handler as handler
+        handler.Lambda.handler({}, None)
+
+    @patch("push_processor.handler.boto3")
+    @patch("push_processor.handler.get_all_keys")
+    def test_lambda_elasticache(self, mock_get_keys, mock_boto):
+        import push_processor.handler as handler
+
+        mock_get_keys.return_value = []
+
+        # Swap out the settings
+        handler.Lambda.s3_open = s3_mock = Mock()
+
+        s3_mock.side_effect = Effect([
+            StringIO.StringIO(
+                json.dumps(dict(redis_name="some_cluster_name",
+                                db_tablename="push_messages_db",
+                                file_type="heka"))
+            ),
+            self._orig_s3_open
+        ])
+
+        # Add in Redis lookups
+        mock_boto.client.return_value = es_mock = Mock()
+        es_mock.describe_cache_clusters.return_value = dict(
+            CacheClusters=[
+                dict(
+                    CacheNodes=[
+                        dict(Endpoint=dict(Address="localhost"))
+                    ]
+                )
+            ]
+        )
+
+        # Do basic run
+        result = handler.Lambda.handler(dict(
+            Records=[dict(s3=dict(
+                          bucket=dict(name="push-test"),
+                          object=dict(key="test_protobuf_stream.gz")
+                          ))]
+        ), None)
+        eq_(result, None)
+        eq_(len(es_mock.describe_cache_clusters.mock_calls), 1)
+
+    @raises(ConfigException)
+    def test_lambda_elasticache_no_cluster(self):
+        import push_processor.handler as handler
+        # Swap out the settings
+        handler.Lambda.s3_open = s3_mock = Mock()
+
+        s3_mock.side_effect = Effect([
+            StringIO.StringIO(
+                json.dumps(dict(redis_name="some_cluster_name",
+                                db_tablename="push_messages_db",
+                                file_type="heka"))
+            ),
+            self._orig_s3_open
+        ])
+
+        # Add in Redis lookups
+        handler.Lambda._es_client = es_mock = Mock()
+        es_mock.describe_cache_clusters.return_value = dict(
+            CacheClusters=[]
+        )
+
+        # Do basic run
+        handler.Lambda.handler(dict(
+            Records=[dict(s3=dict(
+                          bucket=dict(name="push-test"),
+                          object=dict(key="test_protobuf_stream.gz")
+                          ))]
+        ), None)
+
+    @patch("push_processor.db.boto3")
+    def test_lambda(self, mock_boto):
+        import push_processor.handler as handler
+        mock_boto.resource.return_value = mock_ddb = Mock()
+        mock_ddb.Table.return_value = mock_table = Mock()
+        mock_table.query.return_value = dict(Items=[
+            dict(pubkey="ajsildfjasildfjl")
+        ])
         result = handler.Lambda.handler(dict(
             Bucket=""
         ), None)
         eq_(result, "Test event")
 
-        result = handler.Lambda.handler(dict(), None)
-        eq_(result, "No record found in event")
+        # Test event
+        result = handler.Lambda.handler(dict(Bucket=""), None)
+        eq_(result, "Test event")
+
+        # Swap out the settings
+        handler.Lambda.s3_open = s3_mock = Mock()
+
+        s3_mock.side_effect = Effect([
+            StringIO.StringIO(
+                json.dumps(dict(redis_host="localhost",
+                                db_tablename="push_messages_db",
+                                file_type="heka"))
+            ),
+            self._orig_s3_open
+        ])
 
         result = handler.Lambda.handler(dict(
             Records=[dict(s3=dict(
@@ -58,20 +177,46 @@ class TestHandler(unittest.TestCase):
         ), None)
         eq_(result, None)
 
+        s3_mock.side_effect = Effect([
+            StringIO.StringIO(
+                json.dumps(dict(redis_host="localhost",
+                                db_tablename="push_messages_db",
+                                file_type="heka"))
+            ),
+            self._orig_s3_open
+        ])
+        result = handler.Lambda.handler(dict(
+            Records=[dict(s3=dict(
+                          bucket=dict(name="push-test"),
+                          object=dict(key="test_protobuf_stream.gz")
+                          ))]
+        ), None)
+        eq_(result, None)
+
     @patch("push_processor.handler.PubKeyProcessor")
-    def test_lambda_with_json(self, mock_pubkey):
+    @patch("push_processor.handler.get_all_keys")
+    def test_lambda_with_json(self, mock_get_keys, mock_pubkey):
         import push_processor.handler as handler
         mock_pubkey.return_value = mock_processor = Mock()
         mock_processor.latest_messages = {}
-        l = handler.Lambda()
+        mock_get_keys.return_value = []
 
-        l.settings = {
-            "s3_bucket": "push-test",
-            "s3_key": "opts.js",
-            "redis_port": 6379,
-            "db_tablename": "push_messages_db",
-            "file_type": "json"
-        }
+        handler.Lambda.s3_open = s3_mock = Mock()
+        s3_mock.side_effect = Effect([
+            StringIO.StringIO(
+                json.dumps(dict(redis_host="localhost",
+                                db_tablename="push_messages_db",
+                                file_type="json"))
+            ),
+            self._orig_s3_open
+        ])
+
+        l = handler.Lambda(dict(
+            Records=[dict(s3=dict(
+                          bucket=dict(name="push-test"),
+                          object=dict(key="push_dash_logs.json")
+                          ))]
+        ), None)
 
         result = l.handle_event(dict(
             Records=[dict(s3=dict(
@@ -82,11 +227,44 @@ class TestHandler(unittest.TestCase):
         eq_(result, None)
         eq_(len(mock_processor.process_message.mock_calls), 407)
 
+    @patch("push_processor.handler.get_all_keys")
+    def test_skip_processor_file(self, mock_get_keys):
+        import push_processor.handler as handler
+
+        mock_get_keys.return_value = []
+        handler.Lambda.s3_open = s3_mock = Mock()
+        s3_mock.side_effect = Effect([
+            StringIO.StringIO(
+                json.dumps(dict(redis_host="localhost",
+                                db_tablename="push_messages_db",
+                                file_type="json"))
+            ),
+        ])
+
+        handler.Lambda.handler(dict(
+            Records=[dict(s3=dict(
+                          bucket=dict(name="push-test"),
+                          object=dict(key="processor_settings.json")
+                          ))]
+        ), None)
+
     def test_json_process(self):
+        import push_processor.handler as handler
         pkey = uuid.uuid4().hex
         from push_processor.processor.pubkey import PubKeyProcessor
-        from push_processor.handler import Lambda
-        l = Lambda()
+        handler.Lambda.s3_open = s3_mock = Mock()
+        s3_mock.return_value = StringIO.StringIO(
+            json.dumps(dict(redis_host="localhost",
+                            db_tablename="push_messages_db",
+                            file_type="json"))
+        )
+        l = handler.Lambda(dict(
+            Records=[dict(s3=dict(
+                          bucket=dict(name="push-test"),
+                          object=dict(key="push_dash_logs.json")
+                          ))]
+        ), None)
+
         proc = PubKeyProcessor([pkey])
         msg = json.loads(TEST_MESSAGE)
         msg["Fields"]["jwt"] = {"crypto_key": pkey}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--e git+https://github.com/mozilla-services/push-messages.git@7cf9ea53141f124d8131d65ff7a1a7b32afef8e0#egg=push-messages
 boto3==1.2.6
 gzip_reader==0.1
 protobuf==2.6.1


### PR DESCRIPTION
Changes where the config is read from to the root of the S3 dir that
is having its messages processed. This enables easier deployments in
multi-deployed scenarios.

Makefile updates to reduce the size of the generated lambda function
substantially from ~28 MB to ~4 MB.

Removed push_messages dependency as the single dynamodb call to make
was more efficient to encode directly as part of the substantial
reduction in lambda function package size.

Closes #8 

@jrconlin r?
