### PR TITLE
fix: use new correct location for jwt_crypto_key

### DIFF
--- a/push_processor/processor/pubkey.py
+++ b/push_processor/processor/pubkey.py
@@ -14,7 +14,8 @@ class PubKeyProcessor(object):
         self.total += 1
 
         # Need a message field and jwt
-        if "message" not in message.fields or "jwt" not in message.fields:
+        if ("message" not in message.fields or
+                "jwt_crypto_key" not in message.fields):
             return
 
         # Message needs to be a message delivery or storage on endpoint
@@ -23,7 +24,7 @@ class PubKeyProcessor(object):
             return
 
         # Check the jwt public key for match
-        message_key = message.fields["jwt"]["crypto_key"]
+        message_key = message.fields["jwt_crypto_key"]
 
         # Valid key?
         if message_key not in self.pubkeys:

--- a/push_processor/tests/test_handler.py
+++ b/push_processor/tests/test_handler.py
@@ -267,7 +267,7 @@ class TestHandler(unittest.TestCase):
 
         proc = PubKeyProcessor([pkey])
         msg = json.loads(TEST_MESSAGE)
-        msg["Fields"]["jwt"] = {"crypto_key": pkey}
+        msg["Fields"]["jwt_crypto_key"] = pkey
         msg["Fields"]["message_id"] = "jailj24il2j424ijiljlija"
         msg["Fields"]["message_size"] = 312
         msg["Fields"]["message_ttl"] = 600

--- a/push_processor/tests/test_processor.py
+++ b/push_processor/tests/test_processor.py
@@ -26,15 +26,16 @@ class TestPubKeyProcessor(unittest.TestCase):
         proc.process_message(msg)
         eq_(len(proc.latest_messages), 0)
 
-        msg.fields["jwt"] = dict()
+        msg.fields["message"] = "Something"
+        msg.fields["jwt_crypto_key"] = "fred"
         proc.process_message(msg)
         eq_(len(proc.latest_messages), 0)
 
         msg.fields["message"] = "Successful delivery"
-        msg.fields["jwt"]["crypto_key"] = "fred"
+        msg.fields["jwt_crypto_key"] = "fred"
         proc.process_message(msg)
         eq_(len(proc.latest_messages), 0)
 
-        msg.fields["jwt"]["crypto_key"] = "asdfasdf"
+        msg.fields["jwt_crypto_key"] = "asdfasdf"
         proc.process_message(msg)
         eq_(len(proc.latest_messages), 1)


### PR DESCRIPTION
Due to object squashing in autopush, the jwt crypto key will be
added as jwt_crypto_key, read that appropriately.

@jrconlin r?
